### PR TITLE
revise memory_over_provision case

### DIFF
--- a/integrationtest/vm/virt_plus/over_provision/test_memory_over_provision.py
+++ b/integrationtest/vm/virt_plus/over_provision/test_memory_over_provision.py
@@ -37,8 +37,7 @@ def test():
     target_vm_num = 4
 
     host_res = test_lib.lib_get_cpu_memory_capacity(host_uuids = [host.uuid])
-    real_availableMemory = host_res.availableMemory - \
-            sizeunit.get_size(test_lib.lib_get_reserved_memory())
+    real_availableMemory = host_res.availableMemory
     avail_mem = real_availableMemory * over_provision_rate
     if avail_mem <= 1024*1024*1024:
         test_util.test_skip('Available memory is less than 512MB, skip test.')
@@ -48,7 +47,9 @@ def test():
 
     original_rate = test_lib.lib_set_provision_memory_rate(over_provision_rate)
 
-    new_offering_mem = avail_mem / target_vm_num
+    new_offering_mem = int((avail_mem - 1) / target_vm_num)
+    if (new_offering_mem % 2) != 0 :
+        new_offering_mem = new_offering_mem - 1 
     new_offering = test_lib.lib_create_instance_offering(memorySize = new_offering_mem)
 
     new_offering_uuid = new_offering.uuid


### PR DESCRIPTION
内存的超分测试case，存在错误
在查看后端 代码后发现主存储的可用容量是在减去保留容量后所得到的
后端代码如图：
<img width="299" alt="_20170514232723" src="https://cloud.githubusercontent.com/assets/25655163/26035413/298e7238-38fe-11e7-8dae-98a2bb555d5e.png">

所以 原case  
` real_availableMemory = host_res.availableMemory  -   sizeunit.get_size(test_lib.lib_get_reserved_memory())
`
不应再减去
 `sizeunit.get_size(test_lib.lib_get_reserved_memory())`


此case超分率为2 应判断云主机计算规格是否能被二整除，并处理出现的小数的情况对case做出了修改。


